### PR TITLE
Fixes in package.json file for BIN and Require support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 npm-debug.log*
 node_modules
 reports

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Bootstraps missing tests in TypeScript projects",
   "main": "dist/main.js",
   "bin": {
-    "ts-spec-bootstrapper": "dist/main.js"
+    "ts-spec-bootstrapper": "dist/cli.js"
   },
   "scripts": {
     "start": "npm run build && npm run post-build",

--- a/scripts/post-build.js
+++ b/scripts/post-build.js
@@ -1,7 +1,8 @@
 const fs = require('fs');
 
 const mainFilePath = './dist/main.js';
+const cliFilePath = './dist/cli.js';
 const shebangContent = '#!/usr/bin/env node\n';
 const mainContent = fs.readFileSync(mainFilePath);
 
-fs.writeFileSync(mainFilePath, shebangContent + mainContent);
+fs.writeFileSync(cliFilePath, shebangContent + mainContent);


### PR DESCRIPTION
In order to support using the package with commands such as require you need to define the entry point
using the main key in package.json, however to use it as a command in the PATH you must add a shebang to it
and define it using the bin key.
A problem arises because the shebang makes the entry point technically invalid Javascript and as such it should only be
added to the specific script that is included in the PATH and not on the main Node entry point that is meant to be used with Require.