### PR TITLE
🔧 file finder matches file endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![npm version](https://img.shields.io/npm/v/ts-spec-bootstrapper.svg)](https://img.shields.io/npm/v/ts-spec-bootstrapper.svg)
+
 # TS Spec Bootstrapper
 
 Bootstraps tests for all test-able functions in a TypeScript project. Running this script...

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-spec-bootstrapper",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-spec-bootstrapper",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Bootstraps missing tests in TypeScript projects",
   "main": "dist/main.js",
   "bin": {

--- a/src/helper/file-finder.ts
+++ b/src/helper/file-finder.ts
@@ -1,31 +1,31 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-const fetchFilesInDirectoryForFileExtension = (dir: string, matchPattern: string): Array<any> => {
+const fetchFilesInDirectoryForFileExtension = (dir: string, fileEnding: string): Array<any> => {
   if (!fs.existsSync(dir)) {
     return [];
   }
 
-  const files: Array<any> = fs.readdirSync(dir);
   const matches: Array<string> = [];
 
-  for (let i = 0; i < files.length; i++) {
-    const filePath: string = path.join(dir, files[i]);
-    const isDirectory: boolean = fs.lstatSync(filePath).isDirectory();
+  fs.readdirSync(dir)
+    .forEach((file: string) => {
+      const filePath: string = path.join(dir, file);
+      const isDirectory: boolean = fs.lstatSync(filePath).isDirectory();
 
-    if (isDirectory) {
-      const children = fetchFilesInDirectoryForFileExtension(filePath, matchPattern);
-      matches.push(...children);
-    } else if (filePath.indexOf(matchPattern) >= 0) {
-      matches.push(filePath);
-    }
-  }
+      if (isDirectory) {
+        const children = fetchFilesInDirectoryForFileExtension(filePath, fileEnding);
+        matches.push(...children);
+      } else if (filePath.endsWith(fileEnding)) {
+        matches.push(filePath);
+      }
+    });
 
   return matches;
 };
 
 export class FileFinder {
-  public static getMatchingFiles(rootDir: string, matchPattern: string): Array<string> {
-    return fetchFilesInDirectoryForFileExtension(rootDir, matchPattern);
+  public static getMatchingFiles(rootDir: string, fileEnding: string): Array<string> {
+    return fetchFilesInDirectoryForFileExtension(rootDir, fileEnding);
   }
 }


### PR DESCRIPTION
changes:
- file finder now matches the file endings only
- added npm version display to readme.md
- bumped version number to 0.2.*1*